### PR TITLE
feat(auth): add withAuth and withPublic HOCs for route protection

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,131 @@
+"use client";
+import { FC, useState } from "react";
+import { Formik } from "formik";
+import { Login as LoginType, LoginFormikValues } from "@/type";
+import { loginValidation } from "@/validation.schema";
+import { fetchData } from "@/utils/fetchData.util";
+import { withPublic } from "@/hoc/withPublic";
+
+const Login: FC = () => {
+  const initialValues: LoginFormikValues = {
+    email: "",
+    password: "",
+  };
+  const [error, setError] = useState<string | string[]>("");
+
+  const handlerSubmit = async (value: LoginFormikValues) => {
+    try {
+      const { email, password } = value;
+      const data = await fetchData<LoginType>(
+        "/auth/login/admin",
+        {
+          email,
+          password,
+        },
+        "POST"
+      );
+
+      if (data.message !== undefined) {
+        setError(data.message);
+      } else {
+        setError("");
+        localStorage.setItem("token", data.token!);
+      }
+    } catch (error) {
+      console.error("🚀 ~ handlerSubmit ~ error:", error);
+      setError("Error al iniciar sesión");
+    }
+  };
+
+  return (
+    <section className="min-h-screen flex flex-col items-center justify-center bg-background-cream">
+      {error !== "" && (
+        <span className="w-full max-w-md text-center text-white bg-accent-error p-1 my-5 rounded-lg">
+          {error}
+        </span>
+      )}
+      <div className="bg-white p-8 rounded-lg shadow-lg w-full max-w-md">
+        <div className="text-center mb-8">
+          <h2 className="text-3xl font-bold text-primary-500">Food App</h2>
+          <p className="text-secondary-500 mt-2">
+            Inicie sesión para continuar
+          </p>
+        </div>
+
+        <Formik
+          onSubmit={handlerSubmit}
+          initialValues={initialValues}
+          validationSchema={loginValidation}
+          className="space-y-6"
+        >
+          {({
+            values,
+            errors,
+            touched,
+            handleChange,
+            handleBlur,
+            handleSubmit,
+          }) => (
+            <>
+              <div className="my-5">
+                <label
+                  htmlFor="email"
+                  className="block text-sm font-medium text-secondary-700"
+                >
+                  Correo electrónico
+                </label>
+                <input
+                  type="email"
+                  id="email"
+                  className="mt-1 block w-full px-3 py-2 border border-secondary-200 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 mb-2"
+                  placeholder="email@email.cl"
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  value={values.email}
+                />
+                {errors.email && touched.email && (
+                  <span className="w-full text-white bg-accent-error p-1 my-5 rounded-lg">
+                    {errors.email}
+                  </span>
+                )}
+              </div>
+
+              <div className="my-5">
+                <label
+                  htmlFor="password"
+                  className="block text-sm font-medium text-secondary-700"
+                >
+                  Contraseña
+                </label>
+                <input
+                  type="password"
+                  id="password"
+                  className="mt-1 block w-full px-3 py-2 border border-secondary-200 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 mb-2"
+                  placeholder="Ingrese su contraseña"
+                  onChange={handleChange}
+                  onBlur={handleBlur}
+                  value={values.password}
+                />
+                {errors.password && touched.password && (
+                  <span className="w-full text-white bg-accent-error p-1 my-5 rounded-lg">
+                    {errors.password}
+                  </span>
+                )}
+              </div>
+
+              <button
+                type="submit"
+                onClick={() => handleSubmit()}
+                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+              >
+                Ingresar
+              </button>
+            </>
+          )}
+        </Formik>
+      </div>
+    </section>
+  );
+};
+
+export default withPublic(Login);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,130 +1,13 @@
 "use client";
-import { FC, useState } from "react";
-import { Formik } from "formik";
-import { Login as LoginType, LoginFormikValues } from "@/type";
-import { loginValidation } from "@/validation.schema";
-import { fetchData } from "@/utils/fetchData.util";
+import { withAuth } from "@/hoc/withAuth";
+import { FC } from "react";
 
-const Login: FC = () => {
-  const initialValues: LoginFormikValues = {
-    email: "",
-    password: "",
-  };
-  const [error, setError] = useState<string | string[]>("");
-
-  const handlerSubmit = async (value: LoginFormikValues) => {
-    try {
-      const { email, password } = value;
-      const data = await fetchData<LoginType>(
-        "/auth/login/admin",
-        {
-          email,
-          password,
-        },
-        "POST"
-      );
-
-      if (data.message !== undefined) {
-        setError(data.message);
-      } else {
-        setError("");
-        localStorage.setItem("token", data.token!);
-      }
-    } catch (error) {
-      console.error("🚀 ~ handlerSubmit ~ error:", error);
-      setError("Error al iniciar sesión");
-    }
-  };
-
+const Page: FC = () => {
   return (
     <section className="min-h-screen flex flex-col items-center justify-center bg-background-cream">
-      {error !== "" && (
-        <span className="w-full max-w-md text-center text-white bg-accent-error p-1 my-5 rounded-lg">
-          {error}
-        </span>
-      )}
-      <div className="bg-white p-8 rounded-lg shadow-lg w-full max-w-md">
-        <div className="text-center mb-8">
-          <h2 className="text-3xl font-bold text-primary-500">Food App</h2>
-          <p className="text-secondary-500 mt-2">
-            Inicie sesión para continuar
-          </p>
-        </div>
-
-        <Formik
-          onSubmit={handlerSubmit}
-          initialValues={initialValues}
-          validationSchema={loginValidation}
-          className="space-y-6"
-        >
-          {({
-            values,
-            errors,
-            touched,
-            handleChange,
-            handleBlur,
-            handleSubmit,
-          }) => (
-            <>
-              <div className="my-5">
-                <label
-                  htmlFor="email"
-                  className="block text-sm font-medium text-secondary-700"
-                >
-                  Correo electrónico
-                </label>
-                <input
-                  type="email"
-                  id="email"
-                  className="mt-1 block w-full px-3 py-2 border border-secondary-200 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 mb-2"
-                  placeholder="email@email.cl"
-                  onChange={handleChange}
-                  onBlur={handleBlur}
-                  value={values.email}
-                />
-                {errors.email && touched.email && (
-                  <span className="w-full text-white bg-accent-error p-1 my-5 rounded-lg">
-                    {errors.email}
-                  </span>
-                )}
-              </div>
-
-              <div className="my-5">
-                <label
-                  htmlFor="password"
-                  className="block text-sm font-medium text-secondary-700"
-                >
-                  Contraseña
-                </label>
-                <input
-                  type="password"
-                  id="password"
-                  className="mt-1 block w-full px-3 py-2 border border-secondary-200 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 mb-2"
-                  placeholder="Ingrese su contraseña"
-                  onChange={handleChange}
-                  onBlur={handleBlur}
-                  value={values.password}
-                />
-                {errors.password && touched.password && (
-                  <span className="w-full text-white bg-accent-error p-1 my-5 rounded-lg">
-                    {errors.password}
-                  </span>
-                )}
-              </div>
-
-              <button
-                type="submit"
-                onClick={() => handleSubmit()}
-                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-500 hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
-              >
-                Ingresar
-              </button>
-            </>
-          )}
-        </Formik>
-      </div>
+      <h1>home</h1>
     </section>
   );
 };
 
-export default Login;
+export default withAuth(Page);

--- a/src/hoc/withAuth.tsx
+++ b/src/hoc/withAuth.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { ComponentType, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+export function withAuth<P extends object>(WrappedComponent: ComponentType<P>) {
+  const ProtectedComponent = (props: P) => {
+    const router = useRouter();
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+      const token = localStorage.getItem("token");
+
+      if (!token) {
+        router.replace("/login");
+      } else {
+        setIsLoading(false);
+      }
+    }, [router]);
+
+    if (isLoading) {
+      return <div>Cargando...</div>;
+    }
+
+    return <WrappedComponent {...props} />;
+  };
+
+  ProtectedComponent.displayName = `withAuth(${
+    WrappedComponent.displayName || WrappedComponent.name || "Component"
+  })`;
+
+  return ProtectedComponent;
+}

--- a/src/hoc/withPublic.tsx
+++ b/src/hoc/withPublic.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+export function withPublic<P extends object>(
+  WrappedComponent: React.ComponentType<P>
+) {
+  const PublicComponent = (props: P) => {
+    const router = useRouter();
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+      const token = localStorage.getItem("token");
+
+      if (token) {
+        router.replace("/");
+      } else {
+        setIsLoading(false);
+      }
+    }, [router]);
+
+    if (isLoading) {
+      return <div>Cargando...</div>;
+    }
+
+    return <WrappedComponent {...props} />;
+  };
+
+  PublicComponent.displayName = `withPublic(${
+    WrappedComponent.displayName || WrappedComponent.name || "Component"
+  })`;
+
+  return PublicComponent;
+}


### PR DESCRIPTION
Implement higher-order components `withAuth` and `withPublic` to handle authentication and public route protection. Move login logic to a dedicated `/login` page and wrap it with `withPublic`. Wrap the home page with `withAuth` to ensure only authenticated users can access it.