### PR TITLE
feat(product): add edit functionality and rename modal component

### DIFF
--- a/src/app/dashboard/products/page.tsx
+++ b/src/app/dashboard/products/page.tsx
@@ -2,7 +2,7 @@
 import { useAppDispatch, useAppSelector } from "@/app/hooks";
 import DashboardLayout from "@/components/dashboard/dashboardLayout";
 import CardDashboard from "@/components/dashboard/product/card.dashboard";
-import ModalNewProductDashboard from "@/components/dashboard/product/modalNewProduct.dashboard";
+import ModalFormProductDashboard from "@/components/dashboard/product/modalFormProduct.dashboard";
 import { initial, setMeta } from "@/feature/product.slice";
 import { withAuth } from "@/hoc/withAuth";
 import { useDataFetch } from "@/hooks/useDataFetch.hook";
@@ -47,7 +47,7 @@ const Products: FC = () => {
         </div>
 
         {isModalOpen && (
-          <ModalNewProductDashboard setIsModalOpen={setIsModalOpen} />
+          <ModalFormProductDashboard setIsModalOpen={setIsModalOpen} />
         )}
 
         {products.length === 0 ? (

--- a/src/components/dashboard/product/card.dashboard.tsx
+++ b/src/components/dashboard/product/card.dashboard.tsx
@@ -4,15 +4,24 @@ import { formatChileanPesos } from "@/utils/formatChileanPesos.util";
 import Image from "next/image";
 import { FC, useState } from "react";
 import ModalDetailsProductDashboardComponent from "./modalDetailsProduct.dashboard";
+import ModalFormProductDashboard from "./modalFormProduct.dashboard";
 
 const CardDashboard: FC<CardDashboardProps> = ({ product }) => {
   const [isModalOpenDetails, setIsModalOpenDetails] = useState<boolean>(false);
+  const [isModalOpenEditProduct, setIsModalOpenEditProduct] =
+    useState<boolean>(false);
 
   return (
     <>
       {isModalOpenDetails && (
         <ModalDetailsProductDashboardComponent
           setIsModalOpen={setIsModalOpenDetails}
+          product={product}
+        />
+      )}
+      {isModalOpenEditProduct && (
+        <ModalFormProductDashboard
+          setIsModalOpen={setIsModalOpenEditProduct}
           product={product}
         />
       )}
@@ -55,7 +64,10 @@ const CardDashboard: FC<CardDashboardProps> = ({ product }) => {
           </div>
 
           <div className="flex gap-2 mt-4">
-            <button className="flex-1 bg-primary-500 hover:bg-primary-600 text-white py-2 rounded">
+            <button
+              onClick={() => setIsModalOpenEditProduct(true)}
+              className="flex-1 bg-primary-500 hover:bg-primary-600 text-white py-2 rounded"
+            >
               Edit
             </button>
             <button

--- a/src/components/dashboard/product/modalFormProduct.dashboard.tsx
+++ b/src/components/dashboard/product/modalFormProduct.dashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 import {
   initialValueProductForm,
-  ModalDashboardProps,
+  ModalNewProductDashboardProps,
   Product,
   ProductOpenIA,
 } from "@/type";
@@ -10,20 +10,22 @@ import { Formik } from "formik";
 import { validationFormProduct } from "@/validation.schema";
 import {
   deleteCloudinaryImage,
-  updateCloudinaryImage,
+  uploadCloudinaryImage,
 } from "@/utils/cloudinary.util";
 import { fetchData } from "@/utils/fetchData.util";
 import { useAppDispatch, useAppSelector } from "@/app/hooks";
 import {
   addProduct,
   addTotalPages,
+  editProduct,
   setHasNextPage,
 } from "@/feature/product.slice";
 import { analyzeImage } from "@/utils/openIA.util";
 import ModalLayoutComponent from "@/components/layouts/modal.layout";
 
-const ModalNewProductDashboard: FC<ModalDashboardProps> = ({
+const ModalFormProductDashboard: FC<ModalNewProductDashboardProps> = ({
   setIsModalOpen,
+  product = null,
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string | string[]>("");
@@ -34,27 +36,34 @@ const ModalNewProductDashboard: FC<ModalDashboardProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const formInitial: initialValueProductForm = {
-    name: "",
-    price: 0,
-    calories: 0,
-    description: "",
-    category: "",
-    preparationTime: 0,
-    image: "",
-    ingredients: [],
-    baseIngredients: [],
-    extraIngredients: [],
+    id: product?.id || "",
+    name: product?.name || "",
+    price: product?.price || 0,
+    calories: product?.calories || 0,
+    description: product?.description || "",
+    category: product?.category || "",
+    preparationTime: product?.preparationTime || 0,
+    image: product?.imageUrl || "",
+    ingredients: product?.ingredients || [],
+    baseIngredients: product?.baseIngredients || [],
+    extraIngredients: product?.extraIngredients || [],
   };
   const [initialValue, setInitialValue] =
     useState<initialValueProductForm>(formInitial);
 
   const handleOnSubmit = async (values: initialValueProductForm) => {
     setIsSubmitting(true);
-    const file = fileInputRef.current?.files?.[0];
+
+    let file: File | boolean | undefined = true;
+
+    if (product === null) {
+      file = fileInputRef.current?.files?.[0];
+    } else {
+      file = fileInputRef.current?.files?.[0] || true;
+    }
 
     try {
       if (file) {
-        const imageUrl = await updateCloudinaryImage(file);
         const {
           name,
           price,
@@ -65,10 +74,24 @@ const ModalNewProductDashboard: FC<ModalDashboardProps> = ({
           baseIngredients,
           extraIngredients,
           preparationTime,
+          image,
         } = values;
 
+        let imageUrl = image;
+
+        if (product !== null && image !== product.imageUrl) {
+          imageUrl = await uploadCloudinaryImage(file as File);
+          if (product.imageUrl.includes("cloudinary")) {
+            await deleteCloudinaryImage(product.imageUrl);
+          }
+        }
+
+        if (product === null) {
+          imageUrl = await uploadCloudinaryImage(file as File);
+        }
+
         const data = await fetchData<Product>(
-          "/product",
+          product === null ? "/product" : `/product/${product.id}`,
           {
             name,
             price,
@@ -81,19 +104,25 @@ const ModalNewProductDashboard: FC<ModalDashboardProps> = ({
             extraIngredients,
             preparationTime,
           },
-          "POST",
+          product === null ? "POST" : "PATCH",
           localStorage.getItem("token") || ""
         );
 
         if (data.message !== undefined) {
           setError(data.message);
-          await deleteCloudinaryImage(imageUrl);
+          if (product === null) {
+            await deleteCloudinaryImage(imageUrl);
+          }
           modalRef.current?.scrollTo({ top: 0, behavior: "smooth" });
         } else {
           setError("");
-          handleAddProduct(data);
           setInitialValue(formInitial);
           setIsModalOpen(false);
+          if (product === null) {
+            handleAddProduct(data);
+          } else {
+            dispatchApp(editProduct(data));
+          }
         }
       }
     } catch (error) {
@@ -126,7 +155,7 @@ const ModalNewProductDashboard: FC<ModalDashboardProps> = ({
         )}
         <div className="flex justify-between items-center mb-4 w-full">
           <h2 className="text-2xl font-bold text-secondary-800">
-            Add New Product
+            {product ? "Edit Product" : "Add New Product"}
           </h2>
           <button
             onClick={() => setIsModalOpen(false)}
@@ -200,10 +229,9 @@ const ModalNewProductDashboard: FC<ModalDashboardProps> = ({
                 setIsSubmitting(true);
                 const file = fileInputRef.current?.files?.[0];
                 if (file) {
-                  const imageUrl = await updateCloudinaryImage(file);
+                  const imageUrl = await uploadCloudinaryImage(file);
                   img = imageUrl;
                   const data: ProductOpenIA = await analyzeImage(imageUrl);
-                  console.log("🚀 ~ completeIa ~ data:", data);
                   setFieldValue("name", data.name || "");
                   setFieldValue("price", data.product_price || 0);
                   setFieldValue("description", data.description || "");
@@ -367,7 +395,7 @@ const ModalNewProductDashboard: FC<ModalDashboardProps> = ({
                     accept="image/*"
                     className="hidden"
                   />
-                  {values.image !== "" && (
+                  {values.image !== "" && product === null && (
                     <button
                       type="button"
                       onClick={() => completeIa()}
@@ -605,8 +633,10 @@ const ModalNewProductDashboard: FC<ModalDashboardProps> = ({
                         </svg>
                         Saving...
                       </>
-                    ) : (
+                    ) : product === null ? (
                       "Save Product"
+                    ) : (
+                      "Update Product"
                     )}
                   </button>
                 </div>
@@ -619,4 +649,4 @@ const ModalNewProductDashboard: FC<ModalDashboardProps> = ({
   );
 };
 
-export default ModalNewProductDashboard;
+export default ModalFormProductDashboard;

--- a/src/feature/product.slice.ts
+++ b/src/feature/product.slice.ts
@@ -29,6 +29,12 @@ export const productSlice = createSlice({
     addProduct: (state, action: PayloadAction<Product>) => {
       state.products.push(action.payload);
     },
+    editProduct: (state, action: PayloadAction<Product>) => {
+      const index = state.products.findIndex(
+        (product) => product.id === action.payload.id
+      );
+      state.products[index] = action.payload;
+    },
     setMeta: (state, action: PayloadAction<MetaProduct>) => {
       state.meta = action.payload;
     },
@@ -47,6 +53,7 @@ export const productSlice = createSlice({
 export const {
   initial,
   addProduct,
+  editProduct,
   setMeta,
   addTotalPages,
   addPage,

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -234,6 +234,10 @@ export interface ModalDashboardProps {
   setIsModalOpen: Dispatch<SetStateAction<boolean>>;
 }
 
+export interface ModalNewProductDashboardProps extends ModalDashboardProps {
+  product?: Product | null;
+}
+
 export interface ModalDetailsProductDashboardComponentProps
   extends ModalDashboardProps {
   product: Product;
@@ -245,6 +249,7 @@ export interface extraIngredients {
 }
 
 export interface initialValueProductForm {
+  id?: string;
   name: string;
   price: number;
   description: string;

--- a/src/utils/cloudinary.util.ts
+++ b/src/utils/cloudinary.util.ts
@@ -1,4 +1,4 @@
-export const updateCloudinaryImage = async (file: File): Promise<string> => {
+export const uploadCloudinaryImage = async (file: File): Promise<string> => {
   try {
     const formData = new FormData();
     formData.append("file", file);

--- a/src/validation.schema.ts
+++ b/src/validation.schema.ts
@@ -19,7 +19,11 @@ export const validationFormProduct = Yup.object().shape({
     .required("Image is required")
     .test("is-valid-image", "Please upload a valid image", (value) => {
       if (!value) return false;
-      return value.startsWith("data:image/");
+      return (
+        value.startsWith("data:image/") ||
+        value.startsWith("http://") ||
+        value.startsWith("https://")
+      );
     }),
   ingredients: Yup.array()
     .of(Yup.string().required("Ingredient cannot be empty"))


### PR DESCRIPTION
Introduce the ability to edit existing products by adding an `editProduct` action to the product slice. Rename `ModalNewProductDashboard` to `ModalFormProductDashboard` to reflect its dual purpose of handling both new and existing products. Update validation schema to accept HTTP/HTTPS image URLs and extend product interfaces to support editing. Add edit button to product cards and integrate the updated modal component.