### PR TITLE
feat(dashboard): add dashboard slice and integrate with components

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,13 +3,31 @@ import DashboardLayout from "@/components/dashboard/dashboardLayout";
 import CardTotalPriceComponent from "@/components/dashboard/home/cardTotalPrice.dashboard.component";
 import TableComponent from "@/components/dashboard/home/table/table.dashboard.component";
 import { withAuth } from "@/hoc/withAuth";
+import { useDataFetch } from "@/hooks/useDataFetch.hook";
+import { Card } from "@/type";
+import { useEffect } from "react";
+import { useAppDispatch, useAppSelector } from "../hooks";
+import { initial } from "@/feature/dashboard.slice";
 
 const DashboardPage = () => {
+  const [data, loading] = useDataFetch<Card[]>("/cart/active/completed");
+  const carts = useAppSelector((state) => state.dashboard.carts);
+  const dispatchApp = useAppDispatch();
+
+  useEffect(() => {
+    if (!loading) {
+      dispatchApp(initial(data));
+    }
+    return () => {};
+  }, [data, dispatchApp, loading]);
+
   return (
     <DashboardLayout selected="Dashboard">
       <div className="space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          <CardTotalPriceComponent />
+        <div className="grid grid-cols-1 gap-6">
+          <CardTotalPriceComponent
+            total={carts.reduce((acc, card) => acc + card.total, 0)}
+          />
         </div>
         <div className="bg-white rounded-lg shadow-sm">
           <div className="px-6 py-4 border-b border-secondary-200">
@@ -18,7 +36,9 @@ const DashboardPage = () => {
             </h2>
           </div>
           <div className="overflow-x-auto">
-            <TableComponent />
+            {carts.map((cart) => (
+              <TableComponent key={cart.id} cart={cart} />
+            ))}
           </div>
         </div>
       </div>

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -2,12 +2,14 @@ import { configureStore } from "@reduxjs/toolkit";
 import orderReducer from "../feature/order.slice";
 import productReducer from "../feature/product.slice";
 import userReducer from "../feature/user.slice";
+import dashboardReducer from "../feature/dashboard.slice";
 
 export const store = configureStore({
   reducer: {
     order: orderReducer,
     product: productReducer,
     user: userReducer,
+    dashboard: dashboardReducer,
   },
 });
 

--- a/src/components/dashboard/home/cardTotalPrice.dashboard.component.tsx
+++ b/src/components/dashboard/home/cardTotalPrice.dashboard.component.tsx
@@ -1,6 +1,10 @@
+import { CardTotalPriceComponentProps } from "@/type";
+import { formatChileanPesos } from "@/utils/formatChileanPesos.util";
 import { FC } from "react";
 
-const CardTotalPriceComponent: FC = () => {
+const CardTotalPriceComponent: FC<CardTotalPriceComponentProps> = ({
+  total,
+}) => {
   return (
     <div className="bg-white rounded-lg shadow-sm p-6">
       <div className="flex items-center">
@@ -8,7 +12,9 @@ const CardTotalPriceComponent: FC = () => {
           <h3 className="text-secondary-500 text-sm font-medium">
             Total Sales
           </h3>
-          <p className="text-2xl font-semibold text-secondary-900">$24,780</p>
+          <p className="text-2xl font-semibold text-secondary-900">
+            {formatChileanPesos(total)}
+          </p>
         </div>
         <div className="bg-primary-100 p-3 rounded-full">
           <svg
@@ -25,10 +31,6 @@ const CardTotalPriceComponent: FC = () => {
             />
           </svg>
         </div>
-      </div>
-      <div className="mt-2">
-        <span className="text-accent-success text-sm font-medium">+12.5%</span>
-        <span className="text-secondary-500 text-sm ml-2">from last month</span>
       </div>
     </div>
   );

--- a/src/components/dashboard/home/table/table.dashboard.component.tsx
+++ b/src/components/dashboard/home/table/table.dashboard.component.tsx
@@ -1,12 +1,13 @@
 import { FC } from "react";
 import TheadComponent from "./thead.dashboard.component";
 import TbodyComponent from "./tbody.dashboard.component";
+import { TableComponentProps } from "@/type";
 
-const TableComponent: FC = () => {
+const TableComponent: FC<TableComponentProps> = ({ cart }) => {
   return (
     <table className="min-w-full divide-y divide-secondary-200">
       <TheadComponent />
-      <TbodyComponent />
+      <TbodyComponent cart={cart} />
     </table>
   );
 };

--- a/src/components/dashboard/home/table/tbody.dashboard.component.tsx
+++ b/src/components/dashboard/home/table/tbody.dashboard.component.tsx
@@ -1,17 +1,27 @@
+import { TableComponentProps } from "@/type";
+import { formatChileanPesos } from "@/utils/formatChileanPesos.util";
 import { FC } from "react";
 
-const TbodyComponent: FC = () => {
+const TbodyComponent: FC<TableComponentProps> = ({ cart }) => {
   return (
     <tbody className="bg-white divide-y divide-secondary-200">
       <tr>
         <td className="px-6 py-4 whitespace-nowrap text-sm text-secondary-900">
-          #12345
+          #{cart.id.slice(5, 10)}
         </td>
         <td className="px-6 py-4 whitespace-nowrap text-sm text-secondary-500">
-          <ul>
-            <li>Product 1</li>
-            <li>Product 2</li>
-            <li>Product 3</li>
+          <ul className="flex flex-col gap-3">
+            {cart.items.map((item) => (
+              <li key={item.product.id}>
+                <div className="flex flex-col">
+                  <div>
+                    {item.product.name} {formatChileanPesos(item.product.price)}{" "}
+                    {item.quantity > 1 && `x${item.quantity}`}
+                  </div>
+                  {item.extra !== 0 && <div> extra: ${item.extra} </div>}
+                </div>
+              </li>
+            ))}
           </ul>
         </td>
         <td className="px-6 py-4 whitespace-nowrap">
@@ -20,7 +30,7 @@ const TbodyComponent: FC = () => {
           </span>
         </td>
         <td className="px-6 py-4 whitespace-nowrap text-sm text-secondary-900">
-          $150.00
+          {formatChileanPesos(cart.total)}
         </td>
       </tr>
     </tbody>

--- a/src/components/dashboard/orders/orders.dashboard.component.tsx
+++ b/src/components/dashboard/orders/orders.dashboard.component.tsx
@@ -91,19 +91,17 @@ const OrdersDashboardComponent: FC<OrdersDashboardProps> = ({ orders }) => {
   };
 
   return (
-    <div className="p-6 bg-[var(--color-background-light)]">
-      <h1 className="text-3xl font-bold text-[var(--color-secondary-800)] mb-6">
+    <div className="p-6 bg-white">
+      <h1 className="text-3xl font-bold text-secondary-800 mb-6">
         Active Orders
       </h1>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {orders.length === 0 && (
-          <div className="flex flex-col items-center justify-center p-8 bg-white rounded-lg shadow-lg border border-[var(--color-secondary-200)]">
-            <span className="text-2xl text-[var(--color-secondary-600)] mb-2">
+          <div className="col-span-1 md:col-span-2 lg:col-span-3 flex flex-col items-center justify-center p-8 bg-white rounded-lg shadow-lg border border-secondary-200">
+            <span className="text-2xl text-secondary-600 mb-2">
               No active orders
             </span>
-            <p className="text-[var(--color-secondary-500)]">
-              New orders will appear here
-            </p>
+            <p className="text-secondary-500">New orders will appear here</p>
           </div>
         )}
         {orders.map((order) => (
@@ -111,7 +109,7 @@ const OrdersDashboardComponent: FC<OrdersDashboardProps> = ({ orders }) => {
             key={order.id}
             className="bg-white rounded-lg shadow-lg overflow-hidden border border-[var(--color-secondary-200)]"
           >
-            <div className="bg-[var(--color-primary-500)] p-4">
+            <div className="bg-primary-500 p-4">
               <div className="flex justify-between items-center">
                 <span className="text-white font-semibold">
                   Order #{order.id.slice(-6)}
@@ -132,7 +130,7 @@ const OrdersDashboardComponent: FC<OrdersDashboardProps> = ({ orders }) => {
                 {order.items.map((item) => (
                   <div key={item._id} className="flex flex-col gap-1">
                     <div className="flex justify-between items-center">
-                      <span className="text-[var(--color-secondary-700)]">
+                      <span className="text-secondary-700">
                         {item.quantity}x {item.product.name}
                       </span>
                       <div className="flex flex-col items-end">
@@ -140,21 +138,21 @@ const OrdersDashboardComponent: FC<OrdersDashboardProps> = ({ orders }) => {
                           {formatChileanPesos(item.price)}
                         </span>
                         {item.extra > 0 && (
-                          <span className="text-xs text-[var(--color-accent-info)]">
+                          <span className="text-xs text-accent-info">
                             (Extra: {formatChileanPesos(item.extra)})
                           </span>
                         )}
                       </div>
                     </div>
                     {item.ingredients && item.ingredients.length > 0 && (
-                      <div className="text-sm text-[var(--color-secondary-500)] pl-4">
+                      <div className="text-sm text-secondary-500 pl-4">
                         <span className="italic">Base: </span>
                         {item.ingredients.join(", ")}
                       </div>
                     )}
                     {item.extraIngredients &&
                       item.extraIngredients.length > 0 && (
-                        <div className="text-sm text-[var(--color-secondary-500)] pl-4">
+                        <div className="text-sm text-secondary-500 pl-4">
                           <span className="italic">Extra: </span>
                           {item.extraIngredients.join(", ")}
                         </div>
@@ -163,12 +161,12 @@ const OrdersDashboardComponent: FC<OrdersDashboardProps> = ({ orders }) => {
                 ))}
               </div>
 
-              <div className="mt-4 pt-4 border-t border-[var(--color-secondary-200)]">
+              <div className="mt-4 pt-4 border-t border-secondary-200">
                 <div className="flex justify-between items-center">
-                  <span className="font-semibold text-[var(--color-secondary-800)]">
+                  <span className="font-semibold text-secondary-800">
                     Total:
                   </span>
-                  <span className="text-[var(--color-primary-700)] font-bold">
+                  <span className="text-primary-700 font-bold">
                     {formatChileanPesos(order.total)}
                   </span>
                 </div>
@@ -205,11 +203,11 @@ const OrdersDashboardComponent: FC<OrdersDashboardProps> = ({ orders }) => {
                         )
                       }
                       placeholder="Enter 4-digit code"
-                      className="w-full px-4 py-2 border border-[var(--color-secondary-300)] rounded-md text-center text-lg tracking-wider"
+                      className="w-full px-4 py-2 border border-secondary-300 rounded-md text-center text-lg tracking-wider"
                     />
                     <button
                       onClick={() => handleVerifyDelivery(order)}
-                      className="w-full py-2 px-4 bg-[var(--color-accent-success)] hover:opacity-90 text-white font-semibold rounded-md transition-colors duration-200"
+                      className="w-full py-2 px-4 bg-accent-success hover:opacity-90 text-white font-semibold rounded-md transition-colors duration-200"
                     >
                       Verify Delivery
                     </button>

--- a/src/feature/dashboard.slice.ts
+++ b/src/feature/dashboard.slice.ts
@@ -1,0 +1,25 @@
+import { Card } from "@/type";
+import { createSlice } from "@reduxjs/toolkit";
+import type { PayloadAction } from "@reduxjs/toolkit";
+
+export interface DashboardState {
+  carts: Card[];
+}
+
+const initialState: DashboardState = {
+  carts: [],
+};
+
+export const dashboardSlice = createSlice({
+  name: "dashboard",
+  initialState,
+  reducers: {
+    initial: (state, action: PayloadAction<Card[]>) => {
+      state.carts = action.payload;
+    },
+  },
+});
+
+export const { initial } = dashboardSlice.actions;
+
+export default dashboardSlice.reducer;

--- a/src/type.d.ts
+++ b/src/type.d.ts
@@ -343,3 +343,11 @@ export type ConfirmOptions = {
 export interface WorkersAndAdminProps {
   type: "worker" | "admin";
 }
+
+export interface CardTotalPriceComponentProps {
+  total: number;
+}
+
+export interface TableComponentProps {
+  cart: Card;
+}


### PR DESCRIPTION
Add a new dashboard slice to manage cart data and integrate it with the table and total price components. Update the dashboard page to fetch and display cart data dynamically. Remove static data and replace it with real cart information, including formatting prices in Chilean pesos.